### PR TITLE
Add initial Markdown documentation for core components.

### DIFF
--- a/docs/cpp/Array1D.md
+++ b/docs/cpp/Array1D.md
@@ -1,0 +1,98 @@
+# Array1D.h
+
+## Overview
+
+The `Array1D.h` file defines a C++ template class `Array1D<T>` designed to store and manage one-dimensional arrays of any data type `T`. It provides a dynamic array implementation with functionalities similar to `std::vector` but includes additional features such as Fortran-like parenthesis `()` for element access, methods for direct pointer access (useful for C/Fortran interoperability), and binary I/O operations. The file also includes explicit template specializations for `Array1D<int>` and `Array1D<double>` which mirror the generic template's functionality but are optimized for these common types.
+
+## Key Components
+
+*   **`Array1D<T>` (Generic Template Class)**:
+    *   Manages a 1D array of elements of type `T`.
+    *   Provides constructors for creating empty arrays, arrays of a specific size, or arrays initialized with a specific value.
+    *   Offers methods for resizing, clearing, accessing elements (via `()` and `[]` operators), getting the size/length, and obtaining raw data pointers.
+    *   Includes methods for inserting/erasing elements, pushing elements to the back, and setting all values to a specific value.
+    *   Supports binary serialization (dumping to/reading from files).
+    *   Contains methods specifically for Python interfacing (`shape`, `assign`, `setArray`, `flatten`, `type`, `DumpBinary4py`, `ReadBinary4py`).
+    *   Member variables `xsize_` (size) and `data_` (std::vector storing elements) are public for easier Python wrapping.
+
+*   **`Array1D<int>` (Template Specialization)**:
+    *   A specialized version of `Array1D` for `int` data type.
+    *   It largely replicates the public interface and functionality of the generic `Array1D<T>` template.
+    *   Includes specific methods `setnpintArray` and `getnpintArray` for interaction with NumPy-like integer arrays (via pointers/vectors).
+
+*   **`Array1D<double>` (Template Specialization)**:
+    *   A specialized version of `Array1D` for `double` data type.
+    *   It also largely replicates the public interface and functionality of the generic `Array1D<T>` template.
+    *   Includes specific methods `setnpdblArray` and `getnpdblArray` for interaction with NumPy-like double arrays (via pointers/vectors).
+
+## Important Variables/Constants
+
+For `Array1D<T>` (and its specializations):
+*   **`int xsize_`**: Public member variable storing the number of elements in the array.
+*   **`std::vector<T> data_`**: Public member variable (a `std::vector`) that holds the actual array elements. Making this public facilitates easier integration with Python.
+
+## Usage Examples
+
+```cpp
+#include "Array1D.h" // Assuming this is in the include path
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+    // Using the generic template Array1D<T> with doubles
+    Array1D<double> dblArray(5, 0.0); // Create an array of 5 doubles, initialized to 0.0
+    dblArray(0) = 1.1;
+    dblArray[1] = 2.2; // Can also use [] operator
+    dblArray.PushBack(3.3); // Add an element to the end
+
+    std::cout << "Double Array (size " << dblArray.XSize() << "):" << std::endl;
+    for (int i = 0; i < dblArray.Length(); ++i) {
+        std::cout << "dblArray(" << i << ") = " << dblArray(i) << std::endl;
+    }
+
+    // Using the Array1D<int> specialization
+    Array1D<int> intArray; // Default constructor
+    intArray.Resize(3, 10); // Resize to 3 elements, all initialized to 10
+    intArray.insert(20, 1); // Insert 20 at index 1
+
+    std::cout << "\nInt Array (size " << intArray.XSize() << "):" << std::endl;
+    std::vector<int> intVec = intArray.flatten(); // Get data as std::vector
+    for (size_t i = 0; i < intVec.size(); ++i) {
+        std::cout << "intArray[" << i << "] = " << intVec[i] << std::endl;
+    }
+
+    // Example with std::string
+    Array1D<std::string> strArray(2, "hello");
+    strArray.PushBack("world");
+    std::cout << "\nString Array (size " << strArray.XSize() << "):" << std::endl;
+    for (int i = 0; i < strArray.XSize(); ++i) {
+        std::cout << strArray(i) << " ";
+    }
+    std::cout << std::endl;
+    
+    // Getting array pointer (use with caution)
+    if (dblArray.XSize() > 0) {
+        double* pDbl = dblArray.GetArrayPointer();
+        pDbl[0] = 100.1; // Modify directly
+        std::cout << "\nFirst element of dblArray after pointer modification: " << dblArray(0) << std::endl;
+    }
+
+    return 0;
+}
+
+```
+
+## Dependencies and Interactions
+
+*   **Standard Library Headers**:
+    *   `<string>`, `<string.h>`: For string manipulation (though `string.h` is C-style, `<string>` is C++). `type()` method in generic template returns "string".
+    *   `<iostream>`: For I/O operations (e.g., `DumpBinary4py`, `ReadBinary4py` use `ofstream`/`ifstream`).
+    *   `<vector>`: The internal data storage (`data_`) is an `std::vector<T>`.
+    *   `<fstream>`: Used for file I/O operations (`DumpBinary4py`, `ReadBinary4py`).
+    *   `<iterator>`, `<algorithm>`: Potentially used by `std::vector` operations or for methods like `copy` in specializations.
+    *   `<typeinfo>`: Potentially for type introspection, though not explicitly used in the public interface shown.
+*   **`error_handlers.h`**: Included for UQTk's error handling mechanisms (e.g., `Tantrum` exception, though commented out in `insert`/`erase` methods in the provided header snippet).
+*   **C/Fortran Interoperability**: The `GetArrayPointer()` and `GetConstArrayPointer()` methods are designed to facilitate passing the array data to C or Fortran routines that expect raw pointers.
+*   **Python Interfacing**: Several methods are explicitly commented as being for Python interfacing (e.g., `shape()`, `assign()`, `flatten()`, `type()`, `DumpBinary4py()`, `ReadBinary4py()`, `setnpintArray()`, `getnpintArray()`, `setnpdblArray()`, `getnpdblArray()`). The public nature of `xsize_` and `data_` also supports this.
+```

--- a/docs/cpp/PCBasis.md
+++ b/docs/cpp/PCBasis.md
@@ -1,0 +1,122 @@
+# PCBasis.h / PCBasis.cpp
+
+## Overview
+
+The `PCBasis.h` file and its corresponding implementation in `PCBasis.cpp` define the `PCBasis` class. This class is a fundamental component of the UQ Toolkit (UQTk) for Polynomial Chaos Expansions (PCE). It encapsulates the properties and operations related to univariate orthogonal polynomial bases. The class handles the initialization of different polynomial types (e.g., Hermite-Gaussian, Legendre-Uniform), calculation of quadrature points and weights, evaluation of basis polynomials and their derivatives at specified points, computation of basis polynomial norms, and generation of random samples according to the underlying probability distribution of the basis.
+
+## Key Components
+
+*   **`PCBasis` (Class)**:
+    *   **Constructor `PCBasis(const string type, const double alpha, const double betta, const int maxord)`**: Initializes a univariate polynomial chaos basis.
+        *   `type`: A string specifying the basis type (e.g., "HG" for Hermite-Gaussian, "LU" for Legendre-Uniform, "LG" for Laguerre-Gamma, "JB" for Jacobi-Beta, "SW" for Stieltjes-Wigert, "pdf" for custom from `ab.dat`).
+        *   `alpha`, `betta`: Parameters for certain basis types (e.g., Laguerre, Jacobi).
+        *   `maxord`: The maximum polynomial order for which basis functions and related quantities (like quadrature rules) are pre-computed.
+    *   **`Init1dQuadPoints(int qdpts)`**: Initializes 1D quadrature points and weights appropriate for the selected basis type and order. The number of points `qdpts` is typically related to `maxord`.
+    *   **`Eval1dBasisAtQuadPoints()`**: Evaluates the 1D basis polynomials at the pre-computed quadrature points and stores them.
+    *   **`Eval1dBasisAtCustPoints(Array2D<double>& psi, int kord, const Array1D<double>& custPoints)`**: Evaluates basis polynomials up to order `kord` at user-specified custom points.
+    *   **`EvalBasis(const double &xi, Array1D<double> &basisEvals) const`**: Evaluates all basis polynomials up to `maxord_` at a single point `xi`.
+    *   **`EvalBasis(const double &xi, const int kord, double *basisEvals) const`**: Evaluates basis polynomials up to order `kord` at a single point `xi`, storing results in a raw pointer array.
+    *   **`EvalDerivBasis(const double& xi, Array1D<double>& basisDEvals)`**: Evaluates the first derivatives of Legendre basis polynomials at `xi`. (Note: Currently implemented only for "LU" type).
+    *   **`Eval1dDerivBasisAtCustPoints(Array2D<double>& dpsi, int kord, const Array1D<double>& custPoints)`**: Evaluates first derivatives of Legendre basis polynomials at custom points. (Note: Currently implemented only for "LU" type).
+    *   **`Eval2ndDerivBasis(const double& xi, Array1D<double>& ddP)`**: Evaluates the second derivatives of Legendre basis polynomials at `xi`. (Note: Currently implemented only for "LU" type).
+    *   **`Eval2ndDerivCustPoints(Array2D<double>& psi, int kord, Array1D<double>& custPoints)`**: Evaluates second derivatives of Legendre basis polynomials at custom points. (Note: Currently implemented only for "LU" type).
+    *   **`Eval1dNormSq_Exact(int kord)`**: Computes the exact squared norms of the 1D basis polynomials up to order `kord`.
+    *   **`Get1dNormsSq(Array1D<double>& psi1dSq) const`**: Returns the numerically computed squared norms of the basis functions (via quadrature).
+    *   **`Get1dNormsSqExact(Array1D<double>& psi1dSqExact) const`**: Returns the analytically computed exact squared norms of the basis functions.
+    *   **`GetRandSample(Array1D<double>& randSamples)` / `GetRandSample(double* randSamples, const int& nSamp)`**: Generates random samples from the probability distribution associated with the PC basis.
+    *   **`SeedRandNumGen(const int& seed)`**: Seeds the internal random number generator.
+    *   **`GetQuadRule(Array2D<double>& qPoints, Array1D<double>& qWeights, Array2D<int>& qIndices)`**: Retrieves the computed quadrature points, weights, and indices.
+    *   **`GetQuadPoints(Array2D<double>& quadPoints) const`**: Retrieves the quadrature points.
+    *   **`GetQuadWeights(Array1D<double>& quadWeights) const`**: Retrieves the quadrature weights.
+    *   **`GetBasisAtQuadPoints(Array2D<double>& psi1d) const`**: Retrieves the basis polynomials evaluated at quadrature points.
+    *   **`GetPCType() const`**: Returns the string type of the PC basis (e.g., "HG", "LU").
+    *   **`GetAlpha() const` / `GetBeta() const`**: Return the alpha/beta parameters of the basis.
+    *   **`GetSeed() const`**: Returns the current seed of the random number generator.
+
+## Important Variables/Constants
+
+*   **`string type_`**: Private member storing the type of the polynomial basis (e.g., "HG", "LU").
+*   **`Array2D<double> quadPoints_`**: Private member storing the 1D quadrature points.
+*   **`Array1D<double> quadWeights_`**: Private member storing the 1D quadrature weights.
+*   **`Array2D<double> psi1d_`**: Private member storing the 1D basis functions evaluated at `quadPoints_`. `psi1d_(iqp, iord)` is the value of order `iord` polynomial at quadrature point `iqp`.
+*   **`Array1D<double> psi1dSq_`**: Private member storing the squared norms of the 1D basis functions, computed via quadrature.
+*   **`Array1D<double> psi1dSqExact_`**: Private member storing the analytically exact squared norms of the 1D basis functions.
+*   **`int maxord_`**: Private member storing the maximum order of polynomials considered for this basis instance.
+*   **`double alpha_`, `double beta_`**: Private members storing the parameters for certain polynomial families (e.g., Jacobi, Laguerre).
+*   **`dsfmt_t rnstate_`**: Private member storing the state of the Mersenne Twister random number generator.
+*   **`int rSeed_`**: Private member storing the seed used for the random number generator.
+
+## Usage Examples
+
+```cpp
+#include "PCBasis.h"
+#include "Array1D.h"
+#include "Array2D.h"
+#include <iostream>
+#include <string>
+
+int main() {
+    // Example: Legendre-Uniform basis up to order 5
+    std::string basisType = "LU";
+    double alpha = 0.0; // Not used for LU
+    double beta = 0.0;  // Not used for LU
+    int maxOrder = 5;
+
+    PCBasis legendreBasis(basisType, alpha, beta, maxOrder);
+
+    std::cout << "Basis Type: " << legendreBasis.GetPCType() << std::endl;
+
+    // Get Quadrature Rule
+    Array2D<double> qPoints;
+    Array1D<double> qWeights;
+    Array2D<int> qIndices; // May not be populated for all rule types
+    legendreBasis.GetQuadRule(qPoints, qWeights, qIndices);
+    std::cout << "Number of quadrature points: " << qPoints.XSize() << std::endl;
+    // for (int i = 0; i < qPoints.XSize(); ++i) {
+    //     std::cout << "Point " << i << ": " << qPoints(i,0) << ", Weight: " << qWeights(i) << std::endl;
+    // }
+
+    // Evaluate basis functions at a custom point
+    Array1D<double> custom_point(1);
+    custom_point(0) = 0.5;
+    Array1D<double> basis_evals_at_custom_point(maxOrder + 1);
+    legendreBasis.EvalBasis(custom_point(0), basis_evals_at_custom_point);
+    // std::cout << "\nBasis functions evaluated at " << custom_point(0) << ":" << std::endl;
+    // for (int i = 0; i <= maxOrder; ++i) {
+    //     std::cout << "P_" << i << "(" << custom_point(0) << ") = " << basis_evals_at_custom_point(i) << std::endl;
+    // }
+
+    // Get exact squared norms
+    Array1D<double> norms_sq_exact;
+    legendreBasis.Get1dNormsSqExact(norms_sq_exact); // Will compute if not already
+    // std::cout << "\nExact squared norms:" << std::endl;
+    // for (int i = 0; i <= maxOrder; ++i) {
+    //     std::cout << "||P_" << i << "||^2 = " << norms_sq_exact(i) << std::endl;
+    // }
+    
+    // Generate random samples
+    Array1D<double> samples(10); // Generate 10 samples
+    legendreBasis.GetRandSample(samples);
+    // std::cout << "\nRandom samples from Uniform(-1,1):" << std::endl;
+    // for (int i = 0; i < samples.XSize(); ++i) {
+    //     std::cout << samples(i) << " ";
+    // }
+    // std::cout << std::endl;
+
+    return 0;
+}
+```
+
+## Dependencies and Interactions
+
+*   **`Array1D.h`, `Array2D.h`**: Uses UQTk's `Array1D` and `Array2D` classes for storing quadrature points, weights, basis evaluations, norms, and samples.
+*   **`ftndefs.h`**: Likely contains Fortran interoperability definitions, though not directly evident in the `PCBasis` public interface itself.
+*   **`dsfmt_add.h`**: Header for the double-precision SIMD-oriented Fast Mersenne Twister (dSFMT) random number generator, used in `GetRandSample` and `SeedRandNumGen`.
+*   **`error_handlers.h`**: For UQTk's exception handling (e.g., `Tantrum`).
+*   **`uqtkconfig.h`**: Potentially for UQTk library configuration options.
+*   **`quad.h`**: Contains the `Quad` class, which is used internally by `Init1dQuadPoints` to generate quadrature rules.
+*   **`arrayio.h`**: Used internally, for instance, by `EvalBasis` when `type_` is "pdf" to read `ab.dat`.
+*   **`pcmaps.h`**: Used internally by `GetRandSample` for certain basis types (e.g., "LG", "JB") to map samples from a uniform distribution to the target distribution.
+*   **`combin.h`**: Not directly evident in the provided code snippets for `PCBasis.cpp` but might be used by other parts of the PCE module.
+*   **Standard C++ Libraries**: `<iostream>`, `<string.h>` (or `<cstring>`), `<math.h>` (or `<cmath>`), `<stdio.h>`, `<sstream>`.
+```

--- a/docs/cpp/quad.md
+++ b/docs/cpp/quad.md
@@ -1,0 +1,139 @@
+# quad.h / quad.cpp
+
+## Overview
+
+The `quad.h` file and its implementation `quad.cpp` define the `Quad` class within the UQ Toolkit (UQTk). This class is responsible for generating various types of quadrature rules, which are sets of points and corresponding weights used for numerical integration. It supports 1D and multi-dimensional quadrature rules, including full tensor products and sparse grids. A variety of rule types are available, such as Gauss-Legendre, Gauss-Hermite, Clenshaw-Curtis, Newton-Cotes, and rules based on custom probability density functions (via recursion coefficients).
+
+## Key Components
+
+*   **`Quad` (Class)**:
+    *   **Constructors**:
+        *   `Quad(char *grid_type, char *fs_type, int ndim, int param, double alpha=0.0, double betta=1.0)`: For isotropic quadrature rules (same rule type and parameters in all dimensions).
+            *   `grid_type`: String for rule type (e.g., "LU", "HG", "CC").
+            *   `fs_type`: String for "full" tensor product or "sparse" grid.
+            *   `ndim`: Number of dimensions.
+            *   `param`: Number of points per dimension (for "full") or level (for "sparse").
+            *   `alpha`, `betta`: Parameters for certain PC types (e.g., Laguerre, Jacobi).
+        *   `Quad(Array1D<string>& grid_types, char *fs_type, Array1D<int>& param, Array1D<double>& alphas, Array1D<double>& betas)`: For anisotropic quadrature rules (dimension-specific types and parameters).
+            *   `grid_types`: Array of strings for rule types per dimension.
+            *   `fs_type`: "full" or "sparse".
+            *   `param`: Array of points per dimension or level parameters.
+            *   `alphas`, `bettas`: Arrays of alpha/beta parameters per dimension.
+        *   `Quad()`: Default empty constructor.
+    *   **`SetRule()`**: The primary method that computes and sets the quadrature points and weights based on the parameters provided in the constructor or subsequent setter methods.
+    *   **`GetRule(Array2D<double>& q, Array1D<double>& w)`**: Retrieves the computed quadrature points (`q`) and weights (`w`).
+    *   **`SetDomain(Array1D<double>& aa, Array1D<double>& bb)` / `SetDomain(Array1D<double>& aa)`**: Sets the integration domain endpoints. For compact domains (e.g., Legendre), `aa` and `bb` define lower and upper bounds. For semi-infinite domains (e.g., Laguerre), `aa` might define a lower bound.
+    *   **`GetQdpts(Array2D<double>& q)` / `GetWghts(Array1D<double>& w)`**: Retrieve quadrature points and weights separately.
+    *   **`SetQdpts(Array2D<double>& q)` / `SetWghts(Array1D<double>& w)`**: Allows externally setting quadrature points and weights.
+    *   **`GetNQ()`**: Returns the total number of quadrature points.
+    *   **`SetVerbosity(int verbosity)`**: Sets the verbosity level for output during rule generation.
+    *   **`nextLevel()`**: (Primarily for sparse grids) Computes the points and weights for the next hierarchical level.
+    *   **`SetAlpha(double alpha)` / `SetBeta(double betta)`**: Set alpha/beta parameters for the rule.
+    *   **`SetLevel(int param)`**: Sets the level parameter (relevant for sparse grids).
+    *   **`init()`**: Internal initialization function called by constructors.
+
+## Important Variables/Constants
+
+*   **`QD_MAX`**: A preprocessor macro defining a cap on the maximum number of quadrature points for full tensor-product rules to prevent excessive memory allocation (approx. 20,000,000).
+*   **`QuadRule rule_` (Private Member)**: A struct holding the `Array2D<double> qdpts` (quadrature points) and `Array1D<double> wghts` (quadrature weights). This is the primary storage for the generated rule.
+*   **`string grid_type_` / `Array1D<string> grid_types_`**: Stores the type(s) of quadrature rule (e.g., "LU", "HG").
+*   **`string fs_type_`**: Stores the sparseness type ("full" or "sparse").
+*   **`int ndim_`**: Stores the number of dimensions.
+*   **`int maxlevel_` / `Array1D<int> param_`**: Stores the level or points-per-dimension parameter(s).
+*   **`double alpha_`, `double beta_` / `Array1D<double> alphas_`, `Array1D<double> betas_`**: Stores the alpha and beta parameters for relevant PC/quadrature types.
+*   **`Array1D<double> aa_`, `Array1D<double> bb_`**: Stores the domain endpoints.
+*   **`int quadverbose_`**: Controls verbosity.
+*   **`Array1D<int> growth_rules_`**: Internal variable determining how the number of points grows with level for different 1D rule types in sparse grids.
+
+## Usage Examples
+
+```cpp
+#include "quad.h"
+#include "Array1D.h"
+#include "Array2D.h"
+#include <iostream>
+#include <string>
+#include <vector> // For std::vector in example
+
+int main() {
+    // Example 1: 1D Gauss-Legendre Quadrature, 5 points
+    char grid_type_lu[] = "LU";
+    char fs_type_full[] = "full";
+    int ndim_1d = 1;
+    int npoints_1d = 5;
+    Quad quad1D(grid_type_lu, fs_type_full, ndim_1d, npoints_1d);
+    quad1D.SetRule(); // Compute the rule
+
+    Array2D<double> q_pts_1d;
+    Array1D<double> q_wts_1d;
+    quad1D.GetRule(q_pts_1d, q_wts_1d);
+
+    std::cout << "1D Gauss-Legendre Quadrature (" << quad1D.GetNQ() << " points):" << std::endl;
+    for (int i = 0; i < quad1D.GetNQ(); ++i) {
+        std::cout << "Point: " << q_pts_1d(i, 0) << ", Weight: " << q_wts_1d(i) << std::endl;
+    }
+
+    // Example 2: 2D Full Tensor Product of Gauss-Hermite (3 points) and Gauss-Legendre (2 points)
+    Array1D<std::string> grid_types_2d(2);
+    grid_types_2d(0) = "HG";
+    grid_types_2d(1) = "LU";
+
+    Array1D<int> params_2d(2);
+    params_2d(0) = 3; // 3 points for HG
+    params_2d(1) = 2; // 2 points for LU
+    
+    Array1D<double> alphas_2d(2, 0.0); // Default alpha
+    Array1D<double> betas_2d(2, 1.0);  // Default beta
+
+    Quad quad2D_aniso(grid_types_2d, fs_type_full, params_2d, alphas_2d, betas_2d);
+    quad2D_aniso.SetRule();
+
+    Array2D<double> q_pts_2d;
+    Array1D<double> q_wts_2d;
+    quad2D_aniso.GetRule(q_pts_2d, q_wts_2d);
+
+    std::cout << "\n2D Anisotropic Full Tensor Quadrature (" << quad2D_aniso.GetNQ() << " points):" << std::endl;
+    // for (int i = 0; i < quad2D_aniso.GetNQ(); ++i) {
+    //     std::cout << "Point: (" << q_pts_2d(i, 0) << ", " << q_pts_2d(i, 1) 
+    //               << "), Weight: " << q_wts_2d(i) << std::endl;
+    // }
+
+    // Example 3: 2D Sparse Grid Clenshaw-Curtis, level 2
+    char grid_type_cc[] = "CC";
+    char fs_type_sparse[] = "sparse";
+    int ndim_2d_sparse = 2;
+    int level_sparse = 2; 
+    Quad quadSparse(grid_type_cc, fs_type_sparse, ndim_2d_sparse, level_sparse);
+    // For sparse grids, SetDomain might be important if not default [-1,1]
+    // Array1D<double> domain_a(ndim_2d_sparse, -1.0);
+    // Array1D<double> domain_b(ndim_2d_sparse, 1.0);
+    // quadSparse.SetDomain(domain_a, domain_b);
+    quadSparse.SetRule();
+
+    Array2D<double> q_pts_sparse;
+    Array1D<double> q_wts_sparse;
+    quadSparse.GetRule(q_pts_sparse, q_wts_sparse);
+    std::cout << "\n2D Sparse Clenshaw-Curtis Level " << level_sparse << " (" << quadSparse.GetNQ() << " points):" << std::endl;
+    // Outputting all points can be lengthy for sparse grids.
+    
+    return 0;
+}
+
+```
+
+## Dependencies and Interactions
+
+*   **`Array1D.h`, `Array2D.h`**: Uses UQTk's `Array1D` and `Array2D` classes extensively for storing quadrature points, weights, domain boundaries, parameters, and internal working arrays.
+*   **`error_handlers.h`**: For UQTk's exception handling mechanism (e.g., `Tantrum`).
+*   **`combin.h`**: Contains combinatorial functions like `choose`, used in `getMultiIndexLevel` for sparse grid construction.
+*   **`multiindex.h`**: (Likely, though not explicitly shown in `quad.cpp` direct includes, it's related to `getMultiIndexLevel` logic or used by `combin.h`). Used for managing multi-indices in sparse grid construction.
+*   **`gq.h`**: Contains implementations of 1D Gauss quadrature rules (e.g., `gq`, `gq_gen`, `vandermonde_gq`) which are called by the `create1DRule_*` methods. This is a core dependency for generating the fundamental 1D rules.
+*   **`arrayio.h`**: Used by `create1DRule_pdf` to read recursion coefficients from "ab.dat" and by `create1DRule_GP3` to read Gauss-Patterson rule data.
+*   **`arraytools.h`**: Contains utility functions for array manipulations (e.g., `array1Dto2D`, `merge`, `paddMatCol`, `getRow`, `Trans`, `subMatrix_row`, `subMatrix_col`, `getCol`, `is_equal`), used in rule combination and compression.
+*   **Standard C++ Libraries**: `<math.h>` (or `<cmath>`), `<assert.h>`, `<cfloat>`, `<iostream>`, `<string.h>` (or `<cstring>`), `<stdio.h>`, `<sstream>`.
+
+**Interactions:**
+*   The `Quad` class is often used by other UQTk components that require numerical integration, such as those performing Galerkin projection in Polynomial Chaos Expansions (e.g., `PCSet` might use `Quad` to define its integration rule).
+*   The `SetRule()` method orchestrates calls to various private helper functions to first create 1D rules (`create1DRule_*`) and then combine them for multi-dimensional rules (e.g., `MultiplyTwoRules`, `AddTwoRules`, `SubtractTwoRules` for sparse grids).
+*   The `compressRule()` method is important for sparse grids to merge duplicate quadrature points that arise from the combination formula and sum their weights.
+```

--- a/docs/python/adaptation_tools.md
+++ b/docs/python/adaptation_tools.md
@@ -1,0 +1,100 @@
+# adaptation_tools.py
+
+## Overview
+
+This file, `adaptation_tools.py`, is a component of the UQ Toolkit (UQTk). It focuses on providing tools for dimensionality reduction and adaptation in Polynomial Chaos Expansions (PCE). The main idea is to find a rotation in the input parameter space such that most of the variance of the Quantity of Interest (QoI) is captured by a lower-dimensional manifold. This allows for more efficient PCE representations, especially for problems where the QoI is primarily sensitive to a few linear combinations of the original input variables.
+
+## Key Components
+
+*   **`gauss_adaptation(c_k, ndim, method = 0)`**: Computes an isometry (rotation matrix) based on first-order PCE coefficients (`c_k`) of a Gaussian system. This matrix is used to rotate the input space.
+    *   `c_k`: 1D NumPy array of first-order PCE coefficients.
+    *   `ndim`: Dimension of the problem.
+    *   `method`: Integer (0-3) specifying the numerical method to compute the isometry (0: Gram-Schmidt on A with Gaussian coeffs and identity, 1: Orthogonal decomposition of `a*a.T`, 2: Orthogonal decomposition of Householder matrix, 3: Gram-Schmidt with sorted coeffs - recommended).
+*   **`eta_to_xi_mapping(eta, A, zeta = None)`**: Maps points from a lower-dimensional space (`eta`) to the original higher-dimensional input space (`xi`) using the rotation matrix `A`.
+    *   `eta`: N x d0 NumPy array of points in the reduced-dimension space.
+    *   `A`: d x d NumPy array, the rotation matrix (isometry) from `gauss_adaptation`.
+    *   `zeta`: (Optional) N x (d-d0) NumPy array to augment `eta` if `d0 < d`. Defaults to zeros.
+*   **`mi_terms_loc(d1, d2, nord, pc_type, param, sf, pc_alpha=0.0, pc_beta=1.0)`**: Locates the basis terms of a lower-dimensional PCE (`d1`) within the multi-index set of a higher-dimensional PCE (`d2`). This is useful for projecting coefficients between spaces of different dimensionality.
+    *   `d1`: Lower dimension.
+    *   `d2`: Higher dimension.
+    *   `nord`: PC order.
+    *   `pc_type`: Polynomial type (e.g., "HG" for Hermite).
+    *   `param`: Quadrature level or parameter.
+    *   `sf`: Sparsity flag ("sparse" or "full").
+    *   `pc_alpha`, `pc_beta`: Parameters for the polynomial basis (e.g., for Jacobi).
+*   **`l2_error_eta(c_1, c_2, d1, d2, nord, pc_type, param, sf, pc_alpha=0.0, pc_beta=1.0)`**: Calculates the relative L2-norm error between PCE coefficients from a lower-dimensional expansion (`c_1`) and a higher-dimensional expansion (`c_2`), after projecting `c_1` into the higher-dimensional space.
+    *   `c_1`: Coefficients of the lower-dimensional PCE.
+    *   `c_2`: Coefficients of the higher-dimensional PCE.
+    *   Other parameters are similar to `mi_terms_loc`.
+*   **`transf_coeffs_xi(coeffs, nord, ndim, pc_type, param, R, sf="sparse", pc_alpha=0.0, pc_beta=1.0)`**: Transforms PCE coefficients from the reduced (`eta`) space back to the original (`xi`) space. This is primarily for assessing the accuracy of the adaptation method.
+    *   `coeffs`: PCE coefficients in the `eta` space.
+    *   `R`: The rotation matrix.
+    *   Other parameters are similar to `mi_terms_loc`.
+
+## Important Variables/Constants
+
+The functions in this file are primarily driven by their input arguments. There are no standalone global constants defined in this file that dictate general behavior outside of the function calls themselves. Key parameters within functions include:
+*   **`method` in `gauss_adaptation`**: Controls the algorithm for computing the rotation matrix. `method = 3` is noted as the recommended approach.
+*   **`pc_type`, `param`, `sf` in `mi_terms_loc`, `l2_error_eta`, `transf_coeffs_xi`**: These define the characteristics of the Polynomial Chaos Expansion being used (e.g., Hermite polynomials, quadrature rule parameters, sparse/full grid).
+
+## Usage Examples
+
+```python
+# Conceptual Example for using gauss_adaptation and eta_to_xi_mapping
+
+# Assume 'first_order_coeffs' are the 1st order PCE coefficients for a 3D problem
+# first_order_coeffs = np.array([0.8, 0.1, 0.05]) 
+# ndim = 3
+
+# 1. Compute the rotation matrix
+# R = gauss_adaptation(first_order_coeffs, ndim, method=3)
+
+# 2. Define points in a reduced 1D eta space (e.g., quadrature points)
+# eta_points = np.array([[0.5], [1.0], [1.5]]) # N x d0, here d0=1
+
+# 3. Map eta points to the original xi space
+# xi_points = eta_to_xi_mapping(eta_points, R)
+# print("Mapped xi points:", xi_points)
+
+# Conceptual Example for transf_coeffs_xi
+# Assume 'eta_coeffs' are PCE coeffs in a 2D eta-space derived from a 3D xi-space
+# nord = 3
+# ndim_eta = 2 
+# ndim_xi = 3
+# pc_type = "HG" # Hermite polynomials
+# param = 4 # Quadrature level
+# R_matrix = # ... rotation matrix used for adaptation ...
+
+# To transform these eta_coeffs to equivalent xi_coeffs (for comparison/validation):
+# This function internally performs a change of basis.
+# Note: For transf_coeffs_xi, the 'ndim' argument should be the dimension of the space
+# the 'coeffs' are currently in, and 'R' facilitates the transformation to a space of the
+# same dimension but different orientation. If the intention is to project from a lower-dim
+# eta-space to a higher-dim xi-space, a combination of mi_terms_loc and direct coefficient
+# assignment would be used. The `transf_coeffs_xi` function as written appears to assume
+# `coeffs` are for an `ndim` dimensional space that is being rotated.
+
+# For checking convergence (comparing coefficients from a reduced model to a full model):
+# d1_coeffs = # ... coeffs from a d1-dimensional adapted model ...
+# d_full_coeffs = # ... coeffs from the original d-dimensional model ...
+# error, projected_d1_coeffs = l2_error_eta(d1_coeffs, d_full_coeffs, d1, d, nord, ...)
+# print(f"Relative L2 error: {error}")
+```
+
+## Dependencies and Interactions
+
+*   **`sys`**: Used to modify the Python path for local UQTk module imports.
+*   **`uqtkarray`**: UQTk module for custom array types, essential for passing data to and from other UQTk C++ routines.
+*   **`quad` (as `uqtkquad`)**: UQTk module for quadrature rules, likely used by `PCSet` internally.
+*   **`pce` (as `uqtkpce`)**: Core UQTk module providing the `PCSet` class, which defines the PCE basis, multi-indices, and quadrature rules. Functions in `adaptation_tools.py` extensively use `PCSet` objects.
+*   **`tools` (as `uqtktools`)**: General UQTk tools.
+*   **`pce_tools` (from `PyUQTk.PyPCE` or local path)**: Provides helper functions for PCE operations, such as `UQTkGetQuadPoints`. `transf_coeffs_xi` explicitly uses `pce_tools.UQTkGetQuadPoints`.
+*   **`numpy` (as `np`)**: Foundational library for numerical computation in Python. All data arrays (coefficients, points, matrices) are handled as NumPy arrays. Functions like `np.linalg.qr`, `np.linalg.eigh`, `np.dot`, `np.hstack`, `np.where`, `np.all`, `np.linalg.norm` are used.
+
+**Interactions:**
+*   The workflow typically starts with `gauss_adaptation` to find a rotation.
+*   This rotation is then used in `eta_to_xi_mapping` to transform sample points between the original and reduced spaces.
+*   Functions like `mi_terms_loc` and `l2_error_eta` are used to analyze and compare PCEs constructed in these different spaces (e.g., a full PCE in `xi` space vs. an adapted PCE in `eta` space).
+*   `transf_coeffs_xi` is a specialized tool for transforming coefficients under rotation, useful for validating the adaptation process.
+*   All functions rely on `PCSet` objects (from `uqtkpce`) to define the PCE context (polynomial type, order, dimension, quadrature).
+```

--- a/docs/python/mcmc.md
+++ b/docs/python/mcmc.md
@@ -1,0 +1,124 @@
+# mcmc.py
+
+## Overview
+
+This file, `mcmc.py`, is part of the UQ Toolkit (UQTk) and provides implementations of Markov Chain Monte Carlo (MCMC) algorithms. These algorithms are used for sampling from probability distributions, particularly posterior distributions in Bayesian inference. The file includes a Hamiltonian MCMC (HMCMC) sampler and a more advanced Delayed Rejection Adaptive MCMC (DRAM) sampler. It also contains helper functions for a specific "banana-shaped" example posterior, used for testing and demonstrating the MCMC samplers.
+
+## Key Components
+
+*   **`HMCMC(U, grad_U, dt, nT, q)`**: Implements the Hamiltonian Monte Carlo (or Hybrid Monte Carlo) algorithm.
+    *   `U`: A function that computes the potential energy (typically -log(posterior)).
+    *   `grad_U`: A function that computes the gradient of the potential energy.
+    *   `dt`: Time step for the leapfrog integrator.
+    *   `nT`: Number of time steps in the leapfrog trajectory.
+    *   `q`: The initial state (position vector) of the chain.
+    *   *Description*: HMCMC uses Hamiltonian dynamics to propose new states, potentially leading to more efficient exploration of the state space compared to simpler MCMC methods, especially in higher dimensions. It uses a leapfrog integrator for simulating the dynamics.
+
+*   **`dram(opts, cini, likTpr, lpinfo)`**: Implements the Delayed Rejection Adaptive MCMC (DRAM) algorithm.
+    *   `opts`: A dictionary containing various options to control the sampler's behavior (see "Important Variables/Constants" for `opts` dictionary keys).
+    *   `cini`: The initial state (1D NumPy array) of the MCMC chain.
+    *   `likTpr`: A user-supplied function that computes the log-likelihood and log-prior. It takes the current sample and `lpinfo` as input and should return a list or tuple `[log_likelihood, log_prior]`.
+    *   `lpinfo`: A user-supplied object containing any additional information or parameters needed by the `likTpr` function.
+    *   *Description*: DRAM combines adaptive MCMC (where the proposal distribution is adapted based on the chain's history) with delayed rejection (which gives a second chance to proposals that would have otherwise been rejected). This can improve sampling efficiency and robustness.
+
+*   **`norm_pdf_multivariate(x, mu, sigma)`**: Helper function to calculate the probability density function (PDF) of a multivariate normal distribution.
+*   **`tranB(x1, x2, a)` / `invTranB(x1, x2, a)`**: Helper functions for coordinate transformation used in the banana-shaped PDF example.
+*   **`plotBanana()`**: Helper function to plot the banana-shaped PDF.
+*   **`postBanana(spl, postinfo)`**: Helper function to compute the log-posterior for the banana-shaped PDF example, designed to be used with the MCMC samplers.
+*   **`dram_ex(method, nsteps)`**: An example function demonstrating how to use the `dram` sampler with the `postBanana` posterior.
+*   **`logPropRatio(iq, spls)`**: Internal helper for `dram` to compute the log proposal ratio for delayed rejection stages.
+*   **`logPostRatio(p1, p2)`**: Internal helper for `dram` to compute the log posterior ratio.
+*   **`getAlpha(spls, post)`**: Internal helper for `dram` to compute the acceptance probability for delayed rejection stages.
+*   **`ucov(spl, splmean, cov, lastup)`**: Internal helper for `dram` to update the covariance matrix during adaptation.
+
+## Important Variables/Constants
+
+*   **`opts` (Dictionary for `dram` function)**: This dictionary controls the behavior of the DRAM sampler. Key parameters include:
+    *   `'method'`: `'am'` (Adaptive Metropolis) or `'dram'` (Delayed Rejection Adaptive MCMC).
+    *   `'nsteps'`: Total number of MCMC steps.
+    *   `'nburn'`: Number of burn-in steps (proposal covariance is fixed).
+    *   `'nadapt'`: Adapt proposal covariance every `nadapt` steps after burn-in.
+    *   `'nfinal'`: Stop adapting covariance after `nfinal` steps.
+    *   `'inicov'`: Initial proposal covariance matrix.
+    *   `'coveps'`: Small epsilon added to diagonal of covariance for numerical stability.
+    *   `'burnsc'`: Factor to scale proposal during burn-in if acceptance is too high/low.
+    *   `'gamma'`: Factor to multiply proposed jump size after burn-in (default 1.0).
+    *   `'ndr'`: Number of delayed rejection stages (if `method='dram'`).
+    *   `'drscale'`: List of scale factors for proposal covariance at each DR stage.
+    *   `'spllo'`, `'splhi'`: Lower and upper bounds for chain samples.
+    *   `'rnseed'`: Optional seed for the random number generator.
+    *   `'tmpchn'`: Optional filename for saving intermediate chain states.
+    *   `'ofreq'`: Frequency of saving intermediate chain states if `tmpchn` is specified.
+
+*   **`Rmat`, `invRmat` (Global variables for `dram`)**: These store the Cholesky decomposition of proposal covariances and their inverses for different delayed rejection stages. They are managed internally by the `dram` function.
+
+## Usage Examples
+
+```python
+# Conceptual Example for HMCMC (details depend on U and grad_U)
+
+# Define potential energy function U(q) -> float
+# def potential_energy(q):
+#     # -log(posterior(q))
+#     return -(-(q[0]**2)/2.0 - (q[1]**2)/2.0) # Example: standard normal
+
+# Define gradient of potential energy grad_U(q) -> np.array
+# def gradient_potential_energy(q):
+#     return np.array([q[0], q[1]]) # Example: standard normal
+
+# initial_q = np.array([0.0, 0.0])
+# dt_hmcmc = 0.1
+# nT_hmcmc = 10
+# num_samples_hmcmc = 1000
+# samples_hmcmc = [initial_q]
+
+# for _ in range(num_samples_hmcmc - 1):
+#     next_q = HMCMC(potential_energy, gradient_potential_energy, dt_hmcmc, nT_hmcmc, samples_hmcmc[-1])
+#     samples_hmcmc.append(next_q)
+
+# print(f"Generated {len(samples_hmcmc)} samples using HMCMC.")
+
+# Example for DRAM (using the built-in banana example)
+
+# Number of steps for the DRAM sampler
+# n_dram_steps = 5000
+
+# Run the DRAM example with 'dram' method
+# dram_results = dram_ex(method='dram', nsteps=n_dram_steps)
+
+# Accessing results from dram_results dictionary:
+# chain_samples = dram_results['chain']
+# map_estimate = dram_results['cmap']
+# acceptance_rate = dram_results['accr']
+# print(f"Generated {chain_samples.shape[0]} samples using DRAM.")
+# print(f"MAP estimate: {map_estimate}")
+# print(f"Acceptance rate: {acceptance_rate}")
+
+# To use dram with a custom model, one would define:
+# 1. cini_custom = np.array([...]) # Initial guess
+# 2. opts_custom = {
+#        'method': 'dram', 'nsteps': 10000, 'nburn': 2000, 
+#        'nadapt': 200, 'inicov': np.eye(num_dimensions),
+#        'spllo': np.array([...]), 'splhi': np.array([...]), ... 
+#    } # Options
+# 3. def custom_log_posterior(params, model_info):
+#        # ... calculate log_likelihood and log_prior based on 'params' and 'model_info'
+#        # return [log_likelihood, log_prior]
+#    model_specific_info = { ... } # Any info needed by custom_log_posterior
+# 4. custom_results = dram(opts_custom, cini_custom, custom_log_posterior, model_specific_info)
+```
+
+## Dependencies and Interactions
+
+*   **`numpy` (as `npy`)**: Essential for numerical operations, array manipulations (samples, covariance matrices).
+*   **`scipy.stats`**: Used by the example `norm_pdf_multivariate`, though not directly by the core MCMC algorithms.
+*   **`scipy.linalg`**: Used for Cholesky decomposition (`scipy.linalg.cholesky`) and matrix inversion (`scipy.linalg.inv`) in the `dram` sampler for handling covariance matrices.
+*   **`math`**: Standard math functions.
+*   **`uuid`**: Used by `dram` to generate unique filenames if temporary chain saving is enabled without a specific name.
+*   **`matplotlib.pyplot` (as `plt`)**: Used by the `plotBanana` example function, not by the MCMC algorithms themselves.
+
+**Interactions:**
+*   The MCMC algorithms (`HMCMC`, `dram`) require user-defined functions for the (log) posterior probability (or potential energy and its gradient for HMCMC).
+*   `dram` internally uses helper functions like `ucov` for adaptive covariance updates and `logPropRatio`, `logPostRatio`, `getAlpha` for delayed rejection logic.
+*   The example functions (`postBanana`, `dram_ex`, `plotBanana`, etc.) demonstrate how to set up and use the `dram` sampler for a specific problem.
+```

--- a/docs/python/pce_tools.md
+++ b/docs/python/pce_tools.md
@@ -1,0 +1,72 @@
+# pce_tools.py
+
+## Overview
+
+This file, `pce_tools.py`, is part of the UQ Toolkit (UQTk). It provides a suite of Python functions for performing Polynomial Chaos Expansion (PCE) related computations. These tools facilitate tasks such as mapping random variables to PCE representations, evaluating PCE models, drawing samples from PCEs, performing Galerkin projections, regression, and Bayesian Compressive Sensing (BCS) for PCE coefficient determination. It also includes utilities for sensitivity analysis (Sobol indices) and Kernel Density Estimation (KDE).
+
+## Key Components
+
+*   **`UQTkMap2PCE(pc_model, rvs_in, verbose=0)`**: Obtains a PC representation for random variables described by samples. It uses a Rosenblatt transformation to map input RVs to the PC germ space.
+*   **`UQTkEvalPC(pce_model, pce_coeffs, germ_sample)`**: **Deprecated.** Users are advised to use `UQTkEvaluatePCE` instead.
+*   **`UQTkDrawSamplesPCE(pc_model, pc_coeffs, n_samples)`**: Draws samples of the underlying germ of a PC model and evaluates a given PCE for those samples.
+*   **`UQTkEvaluatePCE(pc_model, pc_coeffs, samples)`**: Evaluates a PCE at a given set of samples of this PCE.
+*   **`UQTkGalerkinProjection(pc_model, f_evaluations)`**: Obtains PC coefficients using Galerkin Projection via UQTk.
+*   **`UQTkRegression(pc_model, f_evaluations, samplepts)`**: Obtains PC coefficients by regression.
+*   **`UQTkBCS(pc_begin, xdata, ydata, eta=1.e-3, ...)`**: Performs Bayesian Compressive Sensing to obtain PC coefficients, potentially with basis growth.
+*   **`UQTkOptimizeEta(pc_start, y, x, etas, niter, nfolds, ...)`**: Helper function for `UQTkBCS` to choose the optimum `eta` value via cross-validation.
+*   **`UQTkEvalBCS(pc_model, f_evaluations, samplepts, sigma2, eta, ...)`**: Performs one iteration of Bayesian Compressive Sensing. Helper function for `UQTkBCS`.
+*   **`UQTkCallBCSDirect(vdm_np, rhs_np, sigma2, eta=1.e-8, ...)`**: Calls C++ BCS routines directly with a Vandermonde matrix and right-hand side.
+*   **`multidim_intersect(arr1, arr2)`**: Finds the intersection of two multi-dimensional NumPy arrays.
+*   **`ind_split(ns, split_method, split_params)`**: Splits indices for cross-validation purposes.
+*   **`UQTkGetQuadPoints(pc_model)`**: Generates quadrature points using UQTk and returns them as a NumPy array.
+*   **`UQTkStDv(pc_model, pc_coeffs)`**: Computes the Standard Deviation of a PCE using UQTk.
+*   **`UQTkGSA(pc_model, pc_coeffs)`**: Computes Sobol' sensitivity indices (main, total, and joint).
+*   **`UQTkKDE(fcn_evals)`**: Performs Kernel Density Estimation on a set of function evaluations.
+*   **`UQTkGetMultiIndex(pc_model, ndim)`**: Returns a 2D NumPy array of the PC multi-index.
+*   **`UQTkPlotMiDims(pc_model, c_k, ndim, nord, type)`**: Creates a plot showing the magnitude of PC coefficients for each order.
+*   **`kfold_split(nsamples, nfolds, seed=13)`**: Returns a dictionary of training and testing indices for k-fold cross-validation.
+*   **`kfoldCV(x, y, nfolds=3, seed=13)`**: Splits data (x and y) into training/testing pairs for k-fold cross-validation.
+
+## Important Variables/Constants
+
+While the file primarily defines functions, some functions have important default parameters or internal constants that affect their behavior. For example:
+*   **`UQTkBCS` parameters**: `eta` (stopping threshold), `niter` (iterations for order growth), `mindex_growth` (basis growth method), `sigma2` (initial noise variance).
+*   **`UQTkCallBCSDirect` parameters**: `eta` (stopping threshold).
+*   **Internal constants in `UQTkEvalBCS`**: `adaptive`, `optimal`, `scale` for BCS configuration.
+
+## Usage Examples
+
+```python
+# Conceptual Example for UQTkEvaluatePCE
+# Assuming 'pc_model' is a UQTk PC object, 'coeffs' is a NumPy array of PC coefficients,
+# and 'samples_xi' is a NumPy array of samples in the germ space.
+
+# pce_evaluations = UQTkEvaluatePCE(pc_model, coeffs, samples_xi)
+# print(f"PCE evaluated at samples: {pce_evaluations}")
+
+# Conceptual Example for UQTkGalerkinProjection
+# Assuming 'pc_model' is a UQTk PC object and 'func_at_quad_pts' is a NumPy
+# array of function evaluations at the PC model's quadrature points.
+
+# pc_coefficients = UQTkGalerkinProjection(pc_model, func_at_quad_pts)
+# print(f"Galerkin projected PC coefficients: {pc_coefficients}")
+```
+
+## Dependencies and Interactions
+
+This file has several dependencies and interactions:
+
+*   **`sys`**: Used to modify Python path for local UQTk module imports.
+*   **`uqtkarray`**: Essential UQTk module for custom array types used throughout the functions.
+*   **`quad` (as `uqtkquad`)**: UQTk module for quadrature-related functionalities.
+*   **`pce` (as `uqtkpce`)**: Core UQTk module for PCE class definitions and basic operations.
+*   **`tools` (as `uqtktools`)**: UQTk module providing various utility tools (e.g., Rosenblatt transformation).
+*   **`bcs`**: UQTk module for Bayesian Compressive Sensing C++ backend.
+*   **`utils.multiindex` (as `uqtkmi`)**: UQTk utility for multi-index operations.
+*   **`numpy` (as `np`)**: Heavily used for numerical operations and array manipulations.
+*   **`scipy.stats` and `math`**: Used for statistical operations (like KDE) and mathematical functions.
+*   **`matplotlib.pyplot` and `matplotlib.rc`**: Used for plotting capabilities, specifically in `UQTkPlotMiDims` and `UQTkOptimizeEta`.
+*   **`functools.reduce`**: Used in `UQTkBCS` for intersecting multi-indices.
+
+The functions in this file often interact with each other. For instance, `UQTkBCS` uses `UQTkOptimizeEta` and `UQTkEvalBCS` as helper functions. Many functions rely on a `pc_model` object, which is typically an instance of a PCE class defined in `uqtkpce`.
+```

--- a/docs/python/pdfs.md
+++ b/docs/python/pdfs.md
@@ -1,0 +1,114 @@
+# pdfs.py
+
+## Overview
+
+This file, `pdfs.py`, is part of the PyUQTk plotting utilities within the UQ Toolkit (UQTk). It provides functions for visualizing one-dimensional and two-dimensional probability density functions (PDFs) from sample data. The visualizations can be rendered as kernel density estimates (KDE), histograms, or scatter plots of the samples themselves. The main (but incomplete in the provided snippet) function `plot_pdfs` seems intended to create a matrix of PDF plots, often used in MCMC analysis (a "triangle plot" or "corner plot").
+
+## Key Components
+
+*   **`plot_pdf1d(sams, pltype='hist', color='b', lw=1, nom_height_factor=10., ax=None)`**: Plots a 1D PDF from samples.
+    *   `sams`: 1D NumPy array of samples.
+    *   `pltype`: Type of plot. Options are:
+        *   `'kde'`: Kernel Density Estimate.
+        *   `'hist'`: Histogram (default).
+        *   `'sam'`: Scatter plot of the samples (plotted along the x-axis at y=0).
+        *   `'nom'`: Vertical lines at sample locations, typically used to show nominal parameter values or discrete samples.
+    *   `color`: Color of the plot.
+    *   `lw`: Line width.
+    *   `nom_height_factor`: Factor to control the height of lines when `pltype='nom'`.
+    *   `ax`: Matplotlib axes object to plot on. If `None`, uses the current axes (`plt.gca()`).
+*   **`plot_pdf2d(samsx, samsy, pltype='kde', ncont=10, color=None, lwidth=1, mstyle='o', ax=None)`**: Plots a 2D PDF from samples.
+    *   `samsx`: 1D NumPy array of samples for the x-axis.
+    *   `samsy`: 1D NumPy array of samples for the y-axis.
+    *   `pltype`: Type of plot. Options are:
+        *   `'kde'`: Kernel Density Estimate, shown as contour lines (default).
+        *   `'sam'`: Scatter plot of the (x, y) samples.
+    *   `ncont`: Number of contour levels for KDE plot.
+    *   `color`: Color of the plot. For KDE, can be a single color string or a list/tuple for multiple contour colors.
+    *   `lwidth`: Line width for KDE contours.
+    *   `mstyle`: Marker style for scatter plot (`pltype='sam'`).
+    *   `ax`: Matplotlib axes object to plot on. If `None`, uses the current axes (`plt.gca()`).
+*   **`plot_pdfs(ind_show=[], samples_file='pchain.dat', plot_type='tri', names_file=None, burnin=0, every=1, nominal_file=None, nsam_xi=1, prangeshow_file=None)`**:
+    *   *(Incomplete in the provided script)* This function is intended to generate a matrix of 1D and 2D PDF plots. Typically, diagonal plots show 1D marginal PDFs, and off-diagonal plots show 2D joint PDFs.
+    *   `ind_show`: Indices of parameters/variables to show.
+    *   `samples_file`: Path to the file containing sample data (e.g., MCMC chain).
+    *   `plot_type`: Type of plot matrix, e.g., `'tri'` for a triangle plot (lower or upper).
+    *   `names_file`: Path to a file containing names for the parameters.
+    *   `burnin`: Number of initial samples to discard (burn-in period).
+    *   `every`: Subsampling rate (take every Nth sample).
+    *   `nominal_file`: Path to a file with nominal parameter values to overlay.
+    *   `nsam_xi`: (Purpose unclear from snippet, possibly related to plotting specific sample indices).
+    *   `prangeshow_file`: Path to a file specifying plot ranges for parameters.
+
+## Important Variables/Constants
+
+This file does not define significant standalone variables or constants that affect general behavior outside of function arguments. The default arguments in the functions act as configurable constants for individual plot calls.
+
+## Usage Examples
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+# Assuming pdfs.py is in the Python path or PyUQTk is installed
+# from PyUQTk.plotting import pdfs # Or appropriate import based on project structure
+
+# Generate some sample data
+samples_1d = np.random.normal(loc=0, scale=1, size=1000)
+samples_2d_x = np.random.normal(loc=0, scale=1, size=1000)
+samples_2d_y = 0.5 * samples_2d_x + np.random.normal(loc=0, scale=0.5, size=1000)
+
+# Example for plot_pdf1d
+plt.figure(figsize=(10, 4))
+
+plt.subplot(1, 2, 1)
+# pdfs.plot_pdf1d(samples_1d, pltype='hist', color='skyblue') # Replace with actual import
+# plt.title("1D PDF (Histogram)")
+
+plt.subplot(1, 2, 2)
+# pdfs.plot_pdf1d(samples_1d, pltype='kde', color='salmon', lw=2) # Replace with actual import
+# plt.title("1D PDF (KDE)")
+
+# plt.tight_layout()
+# plt.show()
+
+
+# Example for plot_pdf2d
+plt.figure(figsize=(10, 4))
+
+plt.subplot(1, 2, 1)
+# pdfs.plot_pdf2d(samples_2d_x, samples_2d_y, pltype='sam', color='green', mstyle='.') # Replace with actual import
+# plt.title("2D PDF (Samples)")
+
+plt.subplot(1, 2, 2)
+# pdfs.plot_pdf2d(samples_2d_x, samples_2d_y, pltype='kde', ncont=15, color='purple', lwidth=1.5) # Replace with actual import
+# plt.title("2D PDF (KDE Contours)")
+
+# plt.tight_layout()
+# plt.show()
+
+# Conceptual usage for the (incomplete) plot_pdfs function
+# This is speculative based on typical "triangle plot" functionality.
+# figs, axarr = pdfs.plot_pdfs(
+#     samples_file='path/to/mcmc_chain.dat',
+#     plot_type='tri', # For a lower triangle plot
+#     burnin=1000,
+#     every=10,
+#     names_file='path/to/parameter_names.txt'
+# )
+# if figs:
+#     plt.show()
+```
+*Note: The usage examples for `plot_pdf1d` and `plot_pdf2d` would require uncommenting and ensuring `PyUQTk.plotting.pdfs` is correctly imported. The example for `plot_pdfs` is highly conceptual due to its incomplete state in the script.*
+
+## Dependencies and Interactions
+
+*   **`os`**: Used for operating system interactions (path manipulation, though not explicitly shown in the function bodies provided).
+*   **`sys`**: Used for system-specific parameters and functions (e.g., `sys.exit()` in error cases).
+*   **`PyUQTk.utils.pdf_kde`**: This module is imported and used by `plot_pdf1d` and `plot_pdf2d` when `pltype='kde'` to perform the kernel density estimation.
+*   **`numpy` (as `np`)**: Essential for numerical operations, especially array manipulation for sample data, grid generation for KDE, etc.
+*   **`matplotlib.pyplot` (as `plt`)**: The core library used for generating all plots. Functions interact with `plt.gca()` to get current axes or can accept an `ax` object.
+
+**Interactions:**
+*   The plotting functions (`plot_pdf1d`, `plot_pdf2d`) are designed to be potentially used together, possibly by a higher-level function like the incomplete `plot_pdfs`, to create comprehensive visualizations of multidimensional sample data.
+*   They rely on `pdf_kde.get_pdf` for the KDE calculations.
+```


### PR DESCRIPTION
This commit introduces Markdown documentation for a selection of key Python and C++ files within the UQTk library. The goal is to provide you with a better understanding of these components.

Python modules documented:
- PyUQTk/PyPCE/pce_tools.py
- PyUQTk/PyPCE/adaptation_tools.py
- PyUQTk/inference/mcmc.py
- PyUQTk/plotting/pdfs.py

C++ libraries documented (headers and relevant source files):
- cpp/lib/array/Array1D.h
- cpp/lib/pce/PCBasis.h
- cpp/lib/quad/quad.h

Each documentation file includes:
- An overview of the file's purpose.
- Descriptions of key classes, functions, and components.
- Notes on important variables or constants.
- Conceptual usage examples.
- Information on dependencies and interactions.

The documentation files are stored in `docs/python/` and `docs/cpp/` directories respectively. This effort aims to improve the maintainability and extensibility of the codebase.